### PR TITLE
Add title "Specification" for the root object

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": false,
+  "title": "Specification",
   "definitions": {
     "implementation": {
       "type": "object",


### PR DESCRIPTION
[Typify](https://github.com/oxidecomputer/typify), Rust wrapper generator, does not make root object wrapper unless it has title property